### PR TITLE
Replaced MarkdownSharp with MarkdownDeep

### DIFF
--- a/Journaley/Forms/MainForm.cs
+++ b/Journaley/Forms/MainForm.cs
@@ -1,6 +1,6 @@
 ﻿namespace Journaley.Forms
 {
-    extern alias MDS;
+    extern alias MDD;
 
     using System;
     using System.Collections.Generic;
@@ -21,7 +21,7 @@
     using Journaley.Core.Utilities;
     using Journaley.Core.Watcher;
     using Journaley.Utilities;
-    using MDS.MarkdownSharp;
+    using MDD.MarkdownDeep;
     using Pabo.Calendar;
     using Squirrel;
 
@@ -475,7 +475,9 @@
                 if (this.markdown == null)
                 {
                     this.markdown = new Markdown();
-                    ((MarkdownOptions)this.markdown.Options).AutoNewLines = true;
+
+                    this.markdown.ExtraMode = true;
+                    this.markdown.SafeMode = false;
                 }
 
                 return this.markdown;

--- a/Journaley/Journaley.csproj
+++ b/Journaley/Journaley.csproj
@@ -81,9 +81,10 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\squirrel.windows.0.99.2\lib\Net45\ICSharpCode.SharpZipLib.dll</HintPath>
     </Reference>
-    <Reference Include="MarkdownSharp, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\MarkdownSharp.1.13.0.0\lib\35\MarkdownSharp.dll</HintPath>
-      <Aliases>MDS</Aliases>
+    <Reference Include="MarkdownDeep, Version=1.5.4615.26275, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\MarkdownDeep.NET.1.5\lib\.NetFramework 3.5\MarkdownDeep.dll</HintPath>
+      <Private>True</Private>
+      <Aliases>MDD</Aliases>
     </Reference>
     <Reference Include="Microsoft.WindowsAPICodePack">
       <HintPath>..\packages\winapicp.1.1\lib\Microsoft.WindowsAPICodePack.dll</HintPath>

--- a/Journaley/packages.config
+++ b/Journaley/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="DeltaCompressionDotNet" version="1.0.0" targetFramework="net45" />
-  <package id="MarkdownSharp" version="1.13.0.0" targetFramework="net40-Client" />
+  <package id="MarkdownDeep.NET" version="1.5" targetFramework="net45" />
   <package id="Splat" version="1.6.2" targetFramework="net45" />
   <package id="squirrel.windows" version="0.99.2" targetFramework="net45" />
   <package id="StyleCop.MSBuild" version="4.7.48.2" targetFramework="net40-Client" />


### PR DESCRIPTION
- Just some minor editing with MarkdownDeep.
- NOTE: We can actually now remove the RemoveLineBreaksWithinLists since MarkdownDeep has very good output for lists. The issue now is single-line breaks.
