### PR TITLE
External link fix. Attempt to fix #131.

### DIFF
--- a/Journaley/Forms/MainForm.Designer.cs
+++ b/Journaley/Forms/MainForm.Designer.cs
@@ -450,6 +450,7 @@ namespace Journaley.Forms
             this.webBrowser.Size = new System.Drawing.Size(618, 318);
             this.webBrowser.TabIndex = 0;
             this.webBrowser.DocumentCompleted += new System.Windows.Forms.WebBrowserDocumentCompletedEventHandler(this.WebBrowser_DocumentCompleted);
+            this.webBrowser.Navigating += new System.Windows.Forms.WebBrowserNavigatingEventHandler(this.WebBrowser_Navigating);
             // 
             // contextMenuStripPhotoWithPhoto
             // 

--- a/Journaley/Forms/MainForm.cs
+++ b/Journaley/Forms/MainForm.cs
@@ -2854,6 +2854,21 @@
         }
 
         /// <summary>
+        /// Handles the navigating event of the webBrowser control. In this case, effectively 
+        /// navigating external links to the default web browser.
+        /// </summary>
+        /// <param name="sender">The source of the event.</param>
+        /// <param name="e">The <see cref="WebBrowserNavigatingEventArgs"/> instance containing the event data.</param>
+        private void WebBrowser_Navigating(object sender, WebBrowserNavigatingEventArgs e)
+        {
+            if (!e.Url.ToString().Contains("about:blank"))
+            {
+                Process.Start(e.Url.ToString());
+                e.Cancel = true;
+            }
+        }
+
+        /// <summary>
         /// Handles the MouseMove event of the ToolStripMenuItem control.
         /// </summary>
         /// <param name="sender">The source of the event.</param>


### PR DESCRIPTION
- Added Navigating event that intercepts links and would lead to the default browser using Process.Start.

The original fix (http://stackoverflow.com/a/28319247) did not work on Journaley's footnotes, since it needs to be exactly about:blank. I changed it to Contains.
