### PR TITLE
Added the ability to autolink

### DIFF
--- a/Journaley/Utilities/PostMarkdownParser.cs
+++ b/Journaley/Utilities/PostMarkdownParser.cs
@@ -5,6 +5,7 @@
     using System.IO;
     using System.Linq;
     using System.Text;
+    using System.Text.RegularExpressions;
     using System.Threading.Tasks;
 
     /// <summary>
@@ -18,6 +19,7 @@
         /// - automatically adds break tags on single line breaks.
         /// - makes the first sentence into a header.
         /// - properly parses code blocks enclosed in p tags into pre.
+        /// - auto-linking (converting bare URLs and enclose in a tags).
         /// </summary>
         /// <param name="formattedString">Formatted HTML string</param>
         /// <returns>Properly formatted HTML string for publishing.</returns>
@@ -25,6 +27,9 @@
         {
             StringBuilder builder = new StringBuilder();
             StringBuilder paragraphBuilder = new StringBuilder();
+
+            // Auto-link regex. Only detects http/https links.
+            Regex autoLink = new Regex(@"(?i)\b((?:https?://|www\d{0,3}[.]|[a-z0-9.\-]+[.][a-z]{2,4}/)(?:[^\s()<>]+|\(([^\s()<>]+|(\([^\s()<>]+\)))*\))+(?:\(([^\s()<>]+|(\([^\s()<>]+\)))*\)|[^\s`!()\[\]{};:'"".,<>?«»“”‘’]))", RegexOptions.Multiline);
 
             // -1 - skips check and just dumps the line to builder.
             // 0 - stumbles upon the beginning of a <p> tag/usual parsing.
@@ -36,6 +41,12 @@
             {
                 while ((line = reader.ReadLine()) != null)
                 {
+                    if (!line.Contains("<a href=\"") && !line.Contains("<img src=\""))
+                    {
+                        // Do not replace on links wrapped on img tags or already wrapped a tags.
+                        line = autoLink.Replace(line, "<a href=\"$1\">$1</a>");
+                    }
+
                     if (line.Contains("<p>"))
                     {
                         parseState = 1;

--- a/Journaley/Utilities/PostMarkdownParser.cs
+++ b/Journaley/Utilities/PostMarkdownParser.cs
@@ -19,7 +19,7 @@
         /// - automatically adds break tags on single line breaks.
         /// - makes the first sentence into a header.
         /// - properly parses code blocks enclosed in p tags into pre.
-        /// - auto-linking (converting bare URLs and enclose in a tags).
+        /// - auto-linking (Converting bare HTTP/HTTPs URLS and enclose in a tags).
         /// </summary>
         /// <param name="formattedString">Formatted HTML string</param>
         /// <returns>Properly formatted HTML string for publishing.</returns>
@@ -29,7 +29,7 @@
             StringBuilder paragraphBuilder = new StringBuilder();
 
             // Auto-link regex. Only detects http/https links.
-            Regex autoLink = new Regex(@"(?i)\b((?:https?://|www\d{0,3}[.]|[a-z0-9.\-]+[.][a-z]{2,4}/)(?:[^\s()<>]+|\(([^\s()<>]+|(\([^\s()<>]+\)))*\))+(?:\(([^\s()<>]+|(\([^\s()<>]+\)))*\)|[^\s`!()\[\]{};:'"".,<>?«»“”‘’]))", RegexOptions.Multiline);
+            Regex autoLink = new Regex(@"(?i)\b((?:https?://|www\d{0,3}[.]|[a-z0-9.\-]+[.][a-z]{2,4}/)(?:[^\s()<>]+|\(([^\s()<>]+|(\([^\s()<>]+\)))*\))+(?:\(([^\s()<>]+|(\([^\s()<>]+\)))*\)|[^\s`!()\[\]{};:'"".,<>?«»“”‘’]))", RegexOptions.Singleline);
 
             // -1 - skips check and just dumps the line to builder.
             // 0 - stumbles upon the beginning of a <p> tag/usual parsing.


### PR DESCRIPTION
- Converts single line http/https links and wraps them with a tags. This does not touch `img` tags and already enclosed `a` tags.

The [original regex](http://daringfireball.net/2010/07/improved_regex_for_matching_urls) by John Gruber was used here. It also has a version where it detects all URLs 'ftp or mailto', but I decided to only use http/https only.

Comment if there are any problems with it.
