### PR TITLE
Fix issue #150 "Crash when change...

### DIFF
--- a/Journaley/Forms/MainForm.cs
+++ b/Journaley/Forms/MainForm.cs
@@ -639,6 +639,11 @@
         /// </summary>
         private void UpdateWebBrowser()
         {
+            if (this.selectedEntry == null)
+            {
+                return;
+            }
+
             string initialString = this.SelectedEntry.EntryText;
 
             // Fix for backtick fenced code blocks is to replace it into tilde fenced.


### PR DESCRIPTION
Fix issue #150 "Crash when change text without selecting any entry".
UpdateWebBrowser() will now return immdieately if there is no entry
being selected.